### PR TITLE
Added support for zooming through double tap

### DIFF
--- a/main/src/com/polites/android/DoubleTapListener.java
+++ b/main/src/com/polites/android/DoubleTapListener.java
@@ -6,15 +6,21 @@ import android.view.MotionEvent;
 public class DoubleTapListener extends SimpleOnGestureListener {
 
 	private GestureImageView image;
+	private GestureImageViewTouchListener touchListener;
 	
-	public DoubleTapListener(GestureImageView image) {
+	public DoubleTapListener(GestureImageView image, GestureImageViewTouchListener touchListener) {
 		super();
 		this.image = image;
+		this.touchListener = touchListener;
 	}
 
 	@Override
 	public boolean onDoubleTap(MotionEvent e) {
-		image.reset();
+		if(image.getScale() == touchListener.getStartingScale())
+			image.setScale(touchListener.getDoubleTapScale());
+		else
+			image.reset();
+		
 		return true;
 	}
 }

--- a/main/src/com/polites/android/GestureImageView.java
+++ b/main/src/com/polites/android/GestureImageView.java
@@ -3,6 +3,7 @@ package com.polites.android;
 import java.io.InputStream;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+
 import android.content.Context;
 import android.content.res.Configuration;
 import android.database.Cursor;
@@ -40,6 +41,7 @@ public class GestureImageView extends ImageView  {
 	private float scale = 1.0f;
 	private float maxScale = 5.0f;
 	private float minScale = 0.75f;
+	private float doubleTapScale = maxScale/2;
 
 	private float rotation = 0.0f;
 
@@ -75,6 +77,7 @@ public class GestureImageView extends ImageView  {
 		setImageResource(attrs.getAttributeResourceValue(GLOBAL_NS, "src", -1), true);
 		setMinScale(attrs.getAttributeFloatValue(LOCAL_NS, "min-scale", minScale));
 		setMaxScale(attrs.getAttributeFloatValue(LOCAL_NS, "max-scale", maxScale));
+		setMaxScale(attrs.getAttributeFloatValue(LOCAL_NS, "double-tap-scale", doubleTapScale));
 		setStrict(attrs.getAttributeBooleanValue(LOCAL_NS, "strict", strict));
 		setRecycle(attrs.getAttributeBooleanValue(LOCAL_NS, "recycle", recycle));
 	}
@@ -172,6 +175,7 @@ public class GestureImageView extends ImageView  {
 			gestureImageViewTouchListener = new GestureImageViewTouchListener(this, measuredWidth, measuredHeight);
 			gestureImageViewTouchListener.setMinScale(minScale * startingScale);
 			gestureImageViewTouchListener.setMaxScale(maxScale * startingScale);
+			gestureImageViewTouchListener.setDoubleTapScale(doubleTapScale * startingScale);
 
 			drawable.setBounds(-hWidth,-hHeight,hWidth,hHeight);
 
@@ -375,6 +379,13 @@ public class GestureImageView extends ImageView  {
 		this.maxScale = max;
 		if(gestureImageViewTouchListener != null) {
 			gestureImageViewTouchListener.setMaxScale(max);
+		}
+	}
+	
+	public void setDoubleTapScale(float scale) {
+		this.doubleTapScale = scale;
+		if(gestureImageViewTouchListener != null) {
+			gestureImageViewTouchListener.setDoubleTapScale(scale);
 		}
 	}
 

--- a/main/src/com/polites/android/GestureImageView.java
+++ b/main/src/com/polites/android/GestureImageView.java
@@ -41,7 +41,7 @@ public class GestureImageView extends ImageView  {
 	private float scale = 1.0f;
 	private float maxScale = 5.0f;
 	private float minScale = 0.75f;
-	private float doubleTapScale = maxScale/2;
+	private float doubleTapScale = maxScale/2.0f;
 
 	private float rotation = 0.0f;
 
@@ -77,7 +77,7 @@ public class GestureImageView extends ImageView  {
 		setImageResource(attrs.getAttributeResourceValue(GLOBAL_NS, "src", -1), true);
 		setMinScale(attrs.getAttributeFloatValue(LOCAL_NS, "min-scale", minScale));
 		setMaxScale(attrs.getAttributeFloatValue(LOCAL_NS, "max-scale", maxScale));
-		setMaxScale(attrs.getAttributeFloatValue(LOCAL_NS, "double-tap-scale", doubleTapScale));
+		setDoubleTapScale(attrs.getAttributeFloatValue(LOCAL_NS, "double-tap-scale", doubleTapScale));
 		setStrict(attrs.getAttributeBooleanValue(LOCAL_NS, "strict", strict));
 		setRecycle(attrs.getAttributeBooleanValue(LOCAL_NS, "recycle", recycle));
 	}

--- a/main/src/com/polites/android/GestureImageView.java
+++ b/main/src/com/polites/android/GestureImageView.java
@@ -1,9 +1,11 @@
 package com.polites.android;
 
+import java.io.InputStream;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -12,54 +14,58 @@ import android.graphics.Matrix;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.provider.MediaStore;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.ImageView;
 
 public class GestureImageView extends ImageView  {
-	
+
 	public static final String GLOBAL_NS = "http://schemas.android.com/apk/res/android";
 	public static final String LOCAL_NS = "http://schemas.polites.com/android";
-	
+
 	private final Semaphore drawLock = new Semaphore(0);
 	private Animator animator;
-	
+
 	private Drawable drawable;
-	
+
 	private float x = 0, y = 0;
-	
+
 	private boolean layout = false;
-	
+
 	private float scaleAdjust = 1.0f;
 	private float startingScale = 1.0f;
 
 	private float scale = 1.0f;
 	private float maxScale = 5.0f;
 	private float minScale = 0.75f;
-	
+
 	private float rotation = 0.0f;
-	
+
 	private int lastOrientation = -1;
-	
+
 	private float centerX;
 	private float centerY;
-	
+
 	private int hWidth;
 	private int hHeight;
-	
+
 	private int resId = -1;
 	private boolean recycle = false;
 	private boolean strict = false;
-	
+
 	private int displayHeight;
 	private int displayWidth;
-	
+
 	private int alpha = 255;
 	private ColorFilter colorFilter;
-	
+
+	private int orientation;
+
 	private GestureImageViewListener gestureImageViewListener;
 	private GestureImageViewTouchListener gestureImageViewTouchListener;
-	
+
 	public GestureImageView(Context context, AttributeSet attrs, int defStyle) {
 		this(context, attrs);
 	}
@@ -76,15 +82,15 @@ public class GestureImageView extends ImageView  {
 	public GestureImageView(Context context) {
 		super(context);
 	}
-	
+
 	@Override
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-		
+
 		if(drawable != null) {
 			int orientation = getResources().getConfiguration().orientation;
 			if(orientation == Configuration.ORIENTATION_LANDSCAPE) {
 				displayHeight = MeasureSpec.getSize(heightMeasureSpec);
-				
+
 				if(getLayoutParams().width == LayoutParams.WRAP_CONTENT) {
 					float ratio = (float) getImageWidth() / (float) getImageHeight();
 					displayWidth = Math.round( (float) displayHeight * ratio) ;
@@ -108,10 +114,10 @@ public class GestureImageView extends ImageView  {
 			displayHeight = MeasureSpec.getSize(heightMeasureSpec);
 			displayWidth = MeasureSpec.getSize(widthMeasureSpec);
 		}
-		
+
 		setMeasuredDimension(displayWidth, displayHeight);
 	}
-	
+
 	@Override
 	protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
 		super.onLayout(changed, left, top, right, bottom);
@@ -119,58 +125,58 @@ public class GestureImageView extends ImageView  {
 			setupCanvas(displayWidth, displayHeight, getResources().getConfiguration().orientation);
 		}
 	}
-	
+
 	protected void setupCanvas(int measuredWidth, int measuredHeight, int orientation) {
-		
+
 		if(lastOrientation != orientation) {
 			layout = false;
 			lastOrientation = orientation;
 		}
-		
+
 		if(drawable != null && !layout) {
 			int imageWidth = getImageWidth();
 			int imageHeight = getImageHeight();
 
 			hWidth = Math.round(((float)imageWidth / 2.0f));
 			hHeight = Math.round(((float)imageHeight / 2.0f));
-			
+
 			if(orientation == Configuration.ORIENTATION_LANDSCAPE) {
 				displayHeight = measuredHeight;
-				
+
 				// Calc height based on width
 				float ratio = (float) imageWidth / (float) imageHeight;
-				
+
 				displayWidth = Math.round( (float) displayHeight * ratio);
-				
+
 				startingScale = (float) displayHeight / (float) imageHeight;
 			}
 			else {
 				displayWidth = measuredWidth;
-				
+
 				// Calc height based on width
 				float ratio = (float) imageHeight / (float) imageWidth;
-				
+
 				displayHeight = Math.round( (float) displayWidth * ratio) ;
-				
+
 				startingScale = (float) displayWidth / (float) imageWidth;
 			}
-			
+
 			scaleAdjust = startingScale;
-			
+
 			this.centerX = (float)measuredWidth / 2.0f;
 			this.centerY = (float)measuredHeight / 2.0f;
-			
+
 			x = centerX;
 			y = centerY;
-			
+
 			gestureImageViewTouchListener = new GestureImageViewTouchListener(this, measuredWidth, measuredHeight);
 			gestureImageViewTouchListener.setMinScale(minScale * startingScale);
 			gestureImageViewTouchListener.setMaxScale(maxScale * startingScale);
-			
+
 			drawable.setBounds(-hWidth,-hHeight,hWidth,hHeight);
-			
+
 			setOnTouchListener(gestureImageViewTouchListener);	
-			
+
 			layout = true;
 		}
 	}
@@ -184,7 +190,7 @@ public class GestureImageView extends ImageView  {
 		}
 		return false;
 	}
-	
+
 	protected void recycle() {
 		if(recycle && drawable != null && drawable instanceof BitmapDrawable) {
 			Bitmap bitmap = ((BitmapDrawable)drawable).getBitmap();
@@ -194,6 +200,14 @@ public class GestureImageView extends ImageView  {
 		}
 	}
 	
+//	@Override 
+//    protected void dispatchDraw(Canvas canvas) { 
+//		if(matrix != null) {
+//			canvas.setMatrix(matrix); 
+//		}
+//        super.dispatchDraw(canvas); 
+//    } 
+
 	@Override
 	protected void onDraw(Canvas canvas) {
 		if(layout) {
@@ -201,28 +215,28 @@ public class GestureImageView extends ImageView  {
 				canvas.save();
 				
 				float adjustedScale = scale * scaleAdjust;
-				
+
 				canvas.translate(x, y);
-				
+
 				if(rotation != 0.0f) {
 					canvas.rotate(rotation);
 				}
-				
+
 				if(adjustedScale != 1.0f) {
 					canvas.scale(adjustedScale, adjustedScale);
 				}
-				
+
 				drawable.draw(canvas);
-				
+
 				canvas.restore();
 			}
-			
+
 			if(drawLock.availablePermits() <= 0) {
 				drawLock.release();
 			}
 		}
 	}
-	
+
 	/**
 	 * Waits for a draw
 	 * @param max time to wait for draw (ms)
@@ -231,25 +245,25 @@ public class GestureImageView extends ImageView  {
 	public boolean waitForDraw(long timeout) throws InterruptedException {
 		return drawLock.tryAcquire(timeout, TimeUnit.MILLISECONDS);
 	}
-	
+
 	@Override
 	protected void onAttachedToWindow() {
 		animator = new Animator(this, "GestureImageViewAnimator");
 		animator.start();
-		
+
 		if(resId >= 0 && drawable == null) {
 			setImageResource(resId);
 		}
-		
+
 		super.onAttachedToWindow();
 	}
-	
+
 	public void animationStart(Animation animation) {
 		if(animator != null) {
 			animator.play(animation);
 		}
 	}
-	
+
 	public void animationStop() {
 		if(animator != null) {
 			animator.cancel();
@@ -274,33 +288,33 @@ public class GestureImageView extends ImageView  {
 		if(colorFilter != null) {
 			this.drawable.setColorFilter(colorFilter);
 		}
-		
+
 		if(!original) {
 			layout = false;
 			requestLayout();
 			redraw();
 		}
 	}
-	
+
 	public void setImageBitmap(Bitmap image) {
 		setImageBitmap(image, false);
 	}
-	
+
 	protected void setImageBitmap(Bitmap image, boolean original) {
 		this.drawable = new BitmapDrawable(image);
 		initImage(original);
 	}
-	
+
 	@Override
 	public void setImageDrawable(Drawable drawable) {
 		this.drawable = drawable;
 		initImage(false);
 	}
-	
+
 	public void setImageResource(int id) {
 		setImageResource(id, false);
 	}
-	
+
 	protected void setImageResource(int id, boolean original) {
 		if(this.drawable != null) {
 			this.recycle();
@@ -311,20 +325,36 @@ public class GestureImageView extends ImageView  {
 			setImageBitmap(BitmapFactory.decodeResource(getContext().getResources(), id), original);
 		}
 	}
-	
+
 	public int getImageWidth() {
-		return (drawable == null) ? 0 : drawable.getIntrinsicWidth();
+		if(drawable != null) {
+//			if(orientation == 90 || orientation == 270) {
+//				return drawable.getIntrinsicHeight();
+//			}
+//			else {
+				return drawable.getIntrinsicWidth();
+//			}
+		}
+		return 0;
 	}
 
 	public int getImageHeight() {
-		return  (drawable == null) ? 0 : drawable.getIntrinsicHeight();
+		if(drawable != null) {
+//			if(orientation == 90 || orientation == 270) {
+//				return drawable.getIntrinsicWidth();
+//			}
+//			else {
+				return drawable.getIntrinsicHeight();
+//			}
+		}
+		return 0;
 	}
-	
+
 	public void moveBy(float x, float y) {
 		this.x += x;
 		this.y += y;
 	}
-	
+
 	public void setPosition(float x, float y) {
 		this.x = x;
 		this.y = y;
@@ -340,22 +370,22 @@ public class GestureImageView extends ImageView  {
 			gestureImageViewTouchListener.setMinScale(min);
 		}
 	}
-	
+
 	public void setMaxScale(float max) {
 		this.maxScale = max;
 		if(gestureImageViewTouchListener != null) {
 			gestureImageViewTouchListener.setMaxScale(max);
 		}
 	}
-	
+
 	public void setScale(float scale) {
 		scaleAdjust = scale;
 	}
-	
+
 	public float getScale() {
 		return scaleAdjust;
 	}
-	
+
 	public float getX() {
 		return x;
 	}
@@ -367,15 +397,15 @@ public class GestureImageView extends ImageView  {
 	public boolean isStrict() {
 		return strict;
 	}
-	
+
 	public void setStrict(boolean strict) {
 		this.strict = strict;
 	}
-	
+
 	public boolean isRecycle() {
 		return recycle;
 	}
-	
+
 	public void setRecycle(boolean recycle) {
 		this.recycle = recycle;
 	}
@@ -386,7 +416,7 @@ public class GestureImageView extends ImageView  {
 		scaleAdjust = startingScale;
 		redraw();
 	}
-	
+
 	public void setRotation(float rotation) {
 		this.rotation = rotation;
 	}
@@ -421,11 +451,53 @@ public class GestureImageView extends ImageView  {
 	}
 
 	@Override
-	public void setImageURI(Uri uri) {
-		super.setImageURI(uri);
-		if(strict) {
-			throw new UnsupportedOperationException("Not supported");
-		}		
+	public void setImageURI(Uri mUri) {
+		if ("content".equals(mUri.getScheme())) {
+			try {
+				String[] orientationColumn = {MediaStore.Images.Media.ORIENTATION};
+				
+				Cursor cur = getContext().getContentResolver().query(mUri, orientationColumn, null, null, null);
+				
+				if (cur != null && cur.moveToFirst()) {
+					orientation = cur.getInt(cur.getColumnIndex(orientationColumn[0]));
+				}  
+				
+				InputStream in = null;
+				
+				try {
+					in = getContext().getContentResolver().openInputStream(mUri);
+					Bitmap bmp = BitmapFactory.decodeStream(in);
+					
+					if(orientation != 0) {
+						Matrix m = new Matrix();
+						m.postRotate(orientation);
+						Bitmap rotated = Bitmap.createBitmap(bmp, 0, 0, bmp.getWidth(), bmp.getHeight(), m, true);
+						bmp.recycle();
+						setImageDrawable(new BitmapDrawable(rotated));
+					}
+					else {
+						setImageDrawable(new BitmapDrawable(bmp));
+					}
+				}
+				finally {
+					if(in != null) {
+						in.close();
+					}
+				}
+			}
+			catch (Exception e) {
+				Log.w("GestureImageView", "Unable to open content: " + mUri, e);
+			}
+		}
+		else {
+			setImageDrawable(Drawable.createFromPath(mUri.toString()));
+		}
+
+		if (drawable == null) {
+			Log.e("GestureImageView", "resolveUri failed on bad bitmap uri: " + mUri);
+			// Don't try again.
+			mUri = null;
+		}
 	}
 
 	@Override
@@ -481,7 +553,6 @@ public class GestureImageView extends ImageView  {
 		if(strict) {
 			throw new UnsupportedOperationException("Not supported");
 		}
-		super.setImageMatrix(matrix);
 	}
 
 	@Override
@@ -489,7 +560,6 @@ public class GestureImageView extends ImageView  {
 		if(strict) {
 			throw new UnsupportedOperationException("Not supported");
 		}
-		super.setImageState(state, merge);
 	}
 
 	@Override
@@ -497,7 +567,6 @@ public class GestureImageView extends ImageView  {
 		if(strict) {
 			throw new UnsupportedOperationException("Not supported");
 		}
-		super.setScaleType(scaleType);
 	}
 
 	@Override

--- a/main/src/com/polites/android/GestureImageViewTouchListener.java
+++ b/main/src/com/polites/android/GestureImageViewTouchListener.java
@@ -30,7 +30,8 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 	private float boundaryBottom = 0;
 	
 	private float maxScale = 5.0f;
-	private float minScale = 0.25f;
+	private float minScale = 0.75f;
+	private float doubleTapScale = maxScale/2;
 	
 	private float centerX = 0;
 	private float centerY = 0;
@@ -83,7 +84,7 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 		next.x = image.getX();
 		next.y = image.getY();
 		
-		doubleTapListener = new DoubleTapListener(image);
+		doubleTapListener = new DoubleTapListener(image, this);
 		flingListener = new FlingListener();
 		flingAnimation = new FlingAnimation();
 		
@@ -121,8 +122,8 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 		
 		if(doubleTapDetector.onTouchEvent(event)) {
 			initialDistance = 0;
-			lastScale = startingScale;
-			currentScale = startingScale;
+			lastScale = image.getScale();
+			currentScale = image.getScale();
 			next.x = image.getX();
 			next.y = image.getY();
 			calculateBoundaries();
@@ -291,6 +292,10 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 	}
 	
 	
+	public float getStartingScale() {
+		return startingScale;
+	}
+	
 	public float getMaxScale() {
 		return maxScale;
 	}
@@ -305,6 +310,14 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 
 	public void setMinScale(float minScale) {
 		this.minScale = minScale;
+	}
+	
+	public float getDoubleTapScale() {
+		return doubleTapScale;
+	}
+	
+	public void setDoubleTapScale(float doubleTapScale) {
+		this.doubleTapScale = doubleTapScale;
 	}
 
 	protected void boundCoordinates() {

--- a/main/src/com/polites/android/GestureImageViewTouchListener.java
+++ b/main/src/com/polites/android/GestureImageViewTouchListener.java
@@ -31,7 +31,7 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 	
 	private float maxScale = 5.0f;
 	private float minScale = 0.75f;
-	private float doubleTapScale = maxScale/2;
+	private float doubleTapScale = maxScale/2.0f;
 	
 	private float centerX = 0;
 	private float centerY = 0;


### PR DESCRIPTION
When the image is in its initial scale, double tapping scales the image by `double-tap-scale` (half of max-scale by default).

A couple of things that would improve the experience immensely but are not implemented:
- Scaling would occur centered on the double tap location
- Scaling would be made with an animation — GestureImageView could even offer this as a method (`zoomTo(float scale)`)

I tried to quickly implement them both with no success, mainly because I wasn't being able to integrate my changes into your structure elegantly. I'll leave them as suggestions.

Cheers!
