### PR TITLE
scale changes in the double tap listener were ignored. 

### DIFF
--- a/main/src/com/polites/android/GestureImageViewTouchListener.java
+++ b/main/src/com/polites/android/GestureImageViewTouchListener.java
@@ -137,8 +137,8 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 		
 		if(doubleTapDetector.onTouchEvent(event)) {
 			initialDistance = 0;
-			lastScale = startingScale;
-			currentScale = startingScale;
+			lastScale = image.getScale();;
+			currentScale = image.getScale();;
 			next.x = image.getImageX();
 			next.y = image.getImageY();
 			calculateBoundaries();


### PR DESCRIPTION
changes made to the scale factor inside the double tap listener are now
not overwritten with starting scale.
