### PR TITLE
This one fixes problem with image zoom&position after calling reset()

### DIFF
--- a/main/src/com/polites/android/GestureImageView.java
+++ b/main/src/com/polites/android/GestureImageView.java
@@ -488,6 +488,9 @@ public class GestureImageView extends ImageView  {
 		x = centerX;
 		y = centerY;
 		scaleAdjust = startingScale;
+		if (gestureImageViewTouchListener != null) {
+		    gestureImageViewTouchListener.reset();
+		}
 		redraw();
 	}
 


### PR DESCRIPTION
Hey! I noticed that GestureImageView goes crazy after calling reset() when there is zoom applied. This seems to be a problem with TouchLIstener which should be reset() as well.
