### PR TITLE
Directly Set Zoom Settings

### DIFF
--- a/main/src/com/polites/android/GestureImageView.java
+++ b/main/src/com/polites/android/GestureImageView.java
@@ -460,6 +460,24 @@ public class GestureImageView extends ImageView  {
 			gestureImageViewTouchListener.setMaxScale(max * startingScale);
 		}
 	}
+	
+    /**
+     * Directly set the image scale size.
+     * @param newX new x coordiate after zoom update
+     * @param newY new y coordinate after zoom update
+     * @param newScale direct scale ratio to set the image to
+     * @author Bluefire Productions
+     *
+     */
+    public void setTo(float newX, float newY, float newScale) {
+        x = newX;
+        y = newY;
+        scaleAdjust = newScale;
+        if (gestureImageViewTouchListener != null) {
+            gestureImageViewTouchListener.setTo(newX, newY, newScale);
+        }
+        redraw();
+    }
 
 	public void setScale(float scale) {
 		scaleAdjust = scale;

--- a/main/src/com/polites/android/GestureImageViewTouchListener.java
+++ b/main/src/com/polites/android/GestureImageViewTouchListener.java
@@ -180,6 +180,26 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 		image.animationStart(flingAnimation);
 	}
 	
+	
+    /**
+     * Directly set the image scale size.
+     * @param newX new x coordiate after zoom update
+     * @param newY new y coordiate after zoom update
+     * @param newScale direct scale ration to set the image to
+     * @author Bluefire Productions
+     */
+    public void setTo(float newX, float newY, float newScale) {
+        currentScale = newScale;
+        lastScale = newScale;
+        next.x = newX;
+        next.y = newY;
+        calculateBoundaries();
+        image.setScale(currentScale);
+        image.setPosition(next.x, next.y);
+        image.redraw();
+	
+    }	
+	
 	private void startZoom(MotionEvent e) {
 		inZoom = true;
 		zoomAnimation.reset();


### PR DESCRIPTION
Added the ability to set the current zoom level of the image view externally. This is for use with preset zoom settings buttons one might attach to an outer view.

-Bluefire Productions.
