### PR TITLE
Reseting previous scale when listener is reset

### DIFF
--- a/main/src/com/polites/android/GestureImageViewTouchListener.java
+++ b/main/src/com/polites/android/GestureImageViewTouchListener.java
@@ -456,6 +456,7 @@ public class GestureImageViewTouchListener implements OnTouchListener {
 	
 	public void reset() {
 		currentScale = startingScale;
+                lastScale = currentScale;
 		next.x = centerX;
 		next.y = centerY;
 		calculateBoundaries();


### PR DESCRIPTION
The GestureImageViewTouchListener keeps tabs on how scaled the image was on the last scale event. This allows it to correctly adjust to the new value when a scaling gesture is detected. The problem is that the reset() function does not wipe out the saved last scale value. If you reset the view and then pinch again, the view will immediately jump back to the size it was before the reset and then start scaling again. This PR addresses the issue simply by reseting the previous scale to the initial scale value. 
